### PR TITLE
Import roscpp_init in __init__.py to simplify usage

### DIFF
--- a/src/roscpp_initializer/__init__.py
+++ b/src/roscpp_initializer/__init__.py
@@ -1,0 +1,1 @@
+from . roscpp_initializer import roscpp_init


### PR DESCRIPTION
Hey, thanks for extracting this from the moveit packages and making it work with Python3.
I propose the following modification to make importing a bit easier (get rid of one "roscpp_initializer").

- Move the `__init__.py` to src/roscpp_initializer, so it is actually used.
- Import the `roscpp_init` function inside `__init__.py`, so the import is simplified for the user.

With this, the import is simplified to

    from roscpp_initializer import roscpp_init